### PR TITLE
Update lldpd to 1.0.11 to fix CVE-2020-27827

### DIFF
--- a/src/minimal_overlay/bundles/lldpd/.config
+++ b/src/minimal_overlay/bundles/lldpd/.config
@@ -1,1 +1,1 @@
-LLDPD_SOURCE_URL=https://media.luffy.cx/files/lldpd/lldpd-1.0.3.tar.gz
+LLDPD_SOURCE_URL=https://github.com/lldpd/lldpd/archive/refs/tags/1.0.11.tar.gz


### PR DESCRIPTION
See also https://lldpd.github.io/security.html